### PR TITLE
fix: Calls to external tools use C as lang

### DIFF
--- a/src/rofi-mixer.py
+++ b/src/rofi-mixer.py
@@ -3,6 +3,7 @@ import os
 import re
 import argparse
 
+os.environ["LANG"] = "C"
 VOLUME_DELTA = 5
 res = os.getenv("ROFI_RETV")
 if res is not None:


### PR DESCRIPTION
Users may use languages different than english in there shells, resulting in tools like pactl givig output in those languages and rofi-mixer not finding the lines it is searching for - breaking it effectively